### PR TITLE
Fix handling of partial success

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -21,6 +21,14 @@ type TestStruct3 struct {
 	Value string
 }
 
+type TestStruct4 struct {
+	Value string
+}
+
+type TestStruct5 struct {
+	Value string
+}
+
 type TestInter interface {
 }
 
@@ -56,6 +64,34 @@ func DBTestFunc5(_ context.Context, s TestStruct1) (TestStruct2, error) {
 	fmt.Println("CALLED DBTestFunc5")
 	return TestStruct2{
 		Value: strings.ReplaceAll(s.Value, "-", "--"),
+	}, nil
+}
+
+func DBTestFunc6(_ context.Context, s TestStruct1) (TestStruct3, error) {
+	fmt.Println("CALLED DBTestFunc6")
+	return TestStruct3{
+		Value: s.Value,
+	}, nil
+}
+
+func DBTestFunc7(_ context.Context, s TestStruct3) (TestStruct4, error) {
+	fmt.Println("CALLED DBTestFunc7")
+	return TestStruct4{
+		Value: s.Value,
+	}, nil
+}
+
+func DBTestFuncErr(_ context.Context, s TestStruct1) (TestStruct2, error) {
+	fmt.Println("CALLED DBTestFuncErr")
+	return TestStruct2{
+		Value: s.Value,
+	}, fmt.Errorf("DBTestFunc encountered an error")
+}
+
+func DBTestFuncAfterErr(_ context.Context, s TestStruct2) (TestStruct5, error) {
+	fmt.Println("CALLED DBTestFuncAfterErr")
+	return TestStruct5{
+		Value: s.Value,
 	}, nil
 }
 

--- a/plan.go
+++ b/plan.go
@@ -200,11 +200,17 @@ func (p *plan) run(ctx context.Context, workers uint, dataMap map[string]interfa
 		go worker(ctx, wChan)
 	}
 
+	errs := make([]error, 0)
 	for i := range p.order {
 		err := doWorkAndGetResult(ctx, p.order[i], dataMap, wChan)
 		if err != nil {
-			return err
+			errs = append(errs, err)
 		}
+	}
+	if len(errs) > 0 {
+		// we only return the first error
+		// TODO enhance error handling
+		return errs[0]
 	}
 	return nil
 }


### PR DESCRIPTION
To return all data possible when an error occurs we should continue through plan.order rather than returning on the first error