### PR TITLE
feat: improve data-builder performance and resilience

### DIFF
--- a/databuilder.go
+++ b/databuilder.go
@@ -139,13 +139,18 @@ func getBuilder(bldr any) (*builder, error) {
 		return nil, err
 	}
 
-	t := reflect.TypeOf(bldr)
+	fnValue := reflect.ValueOf(bldr)
+	if fnValue.IsNil() {
+		return nil, ErrInvalidBuilder
+	}
+
+	t := fnValue.Type()
 	out := getStructName(t.Out(0))
-	name := getFuncName(bldr)
+	name := runtime.FuncForPC(fnValue.Pointer()).Name()
 
 	b := &builder{
 		Out:     out,
-		fnValue: reflect.ValueOf(bldr),
+		fnValue: fnValue,
 		Name:    name,
 	}
 	// first in context.Context so we start from second
@@ -153,10 +158,6 @@ func getBuilder(bldr any) (*builder, error) {
 		b.In = append(b.In, getStructName(t.In(i)))
 	}
 	return b, nil
-}
-
-func getFuncName(bldr any) string {
-	return runtime.FuncForPC(reflect.ValueOf(bldr).Pointer()).Name()
 }
 
 func getStructName(t reflect.Type) string {

--- a/databuilder.go
+++ b/databuilder.go
@@ -12,11 +12,10 @@ import (
  */
 
 type builder struct {
-	Builder  any
-	fnValue  reflect.Value // cached reflect.ValueOf(Builder) to avoid repeated reflection
-	In       []string
-	Out      string
-	Name     string
+	fnValue reflect.Value // cached reflect.ValueOf(builder func) to avoid repeated reflection
+	In      []string
+	Out     string
+	Name    string
 }
 
 type db struct {
@@ -146,7 +145,6 @@ func getBuilder(bldr any) (*builder, error) {
 
 	b := &builder{
 		Out:     out,
-		Builder: bldr,
 		fnValue: reflect.ValueOf(bldr),
 		Name:    name,
 	}

--- a/databuilder.go
+++ b/databuilder.go
@@ -12,10 +12,11 @@ import (
  */
 
 type builder struct {
-	Builder any
-	In      []string
-	Out     string
-	Name    string
+	Builder  any
+	fnValue  reflect.Value // cached reflect.ValueOf(Builder) to avoid repeated reflection
+	In       []string
+	Out      string
+	Name     string
 }
 
 type db struct {
@@ -146,6 +147,7 @@ func getBuilder(bldr any) (*builder, error) {
 	b := &builder{
 		Out:     out,
 		Builder: bldr,
+		fnValue: reflect.ValueOf(bldr),
 		Name:    name,
 	}
 	// first in context.Context so we start from second

--- a/databuilder.go
+++ b/databuilder.go
@@ -96,6 +96,9 @@ func IsValidBuilder(builder any) error {
 		// Input can only be a function
 		return ErrInvalidBuilderKind
 	}
+	if reflect.ValueOf(builder).IsNil() {
+		return ErrInvalidBuilder
+	}
 	if t.NumOut() != 2 {
 		// should return a struct and an error
 		return ErrInvalidBuilderNumOutput

--- a/databuilder.go
+++ b/databuilder.go
@@ -88,6 +88,9 @@ func (d *db) Compile(init ...any) (Plan, error) {
 
 // IsValidBuilder checks if the given function is valid or not
 func IsValidBuilder(builder any) error {
+	if builder == nil {
+		return ErrInvalidBuilder
+	}
 	t := reflect.TypeOf(builder)
 	if t.Kind() != reflect.Func {
 		// Input can only be a function

--- a/databuilder_test.go
+++ b/databuilder_test.go
@@ -1,6 +1,7 @@
 package databuilder
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,4 +61,44 @@ func TestCompileCyclic(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = d.Compile()
 	assert.Error(t, err, "cyclic dependency should return an error")
+}
+
+func TestTypedNilBuilderRejected(t *testing.T) {
+	var nilFunc func(context.Context) (TestStruct1, error)
+	d := testNew(t)
+	err := d.AddBuilders(nilFunc)
+	assert.Error(t, err, "typed-nil func should be rejected")
+	assert.ErrorIs(t, err, ErrInvalidBuilder)
+}
+
+func TestContextCancellation(t *testing.T) {
+	d := testNew(t)
+	err := d.AddBuilders(DBTestFunc, DBTestFunc4)
+	assert.NoError(t, err)
+	plan, err := d.Compile(TestStruct1{})
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err = plan.Run(ctx, TestStruct1{Value: "test"})
+	assert.Error(t, err, "cancelled context should return an error")
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestJoinErrorsSingle(t *testing.T) {
+	// Single error should be returned unwrapped
+	sentinel := ErrWTF
+	err := joinErrors([]error{sentinel})
+	assert.Equal(t, sentinel, err, "single error should be returned as-is, not wrapped")
+
+	// No errors
+	err = joinErrors(nil)
+	assert.NoError(t, err)
+
+	// Multiple errors
+	err = joinErrors([]error{ErrWTF, ErrInvalidBuilder})
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrWTF)
+	assert.ErrorIs(t, err, ErrInvalidBuilder)
 }

--- a/databuilder_test.go
+++ b/databuilder_test.go
@@ -69,6 +69,11 @@ func TestTypedNilBuilderRejected(t *testing.T) {
 	err := d.AddBuilders(nilFunc)
 	assert.Error(t, err, "typed-nil func should be rejected")
 	assert.ErrorIs(t, err, ErrInvalidBuilder)
+
+	// IsValidBuilder should also reject typed-nil builders directly
+	err = IsValidBuilder(nilFunc)
+	assert.Error(t, err, "IsValidBuilder should reject typed-nil func")
+	assert.ErrorIs(t, err, ErrInvalidBuilder)
 }
 
 func TestContextCancellation(t *testing.T) {

--- a/databuilder_test.go
+++ b/databuilder_test.go
@@ -86,7 +86,7 @@ func TestContextCancellation(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
-func TestJoinErrorsSingle(t *testing.T) {
+func TestJoinErrors(t *testing.T) {
 	// Single error should be returned unwrapped
 	sentinel := ErrWTF
 	err := joinErrors([]error{sentinel})

--- a/plan.go
+++ b/plan.go
@@ -215,6 +215,9 @@ func (p *plan) run(ctx context.Context, workers uint, dataMap map[string]any) er
 	errs := make([]error, 0)
 	for i := range p.order {
 		if err := ctx.Err(); err != nil {
+			if len(errs) == 0 {
+				return err
+			}
 			return joinErrors(append(errs, err))
 		}
 		err := doWorkAndGetResult(ctx, p.order[i], dataMap, wChan)

--- a/plan.go
+++ b/plan.go
@@ -183,10 +183,21 @@ func doWorkAndGetResult(ctx context.Context, builders []*builder, dataMap map[st
 		name := getStructName(outputs[0].Type())
 		dataMap[name] = outputs[0].Interface()
 	}
-	if len(errs) > 0 {
+	return joinErrors(errs)
+}
+
+// joinErrors returns nil for no errors, the error itself for a single error,
+// or a joined error for multiple errors. This avoids wrapping single errors
+// which would break sentinel checks like err == context.Canceled.
+func joinErrors(errs []error) error {
+	switch len(errs) {
+	case 0:
+		return nil
+	case 1:
+		return errs[0]
+	default:
 		return errors.Join(errs...)
 	}
-	return nil
 }
 
 func (p *plan) run(ctx context.Context, workers uint, dataMap map[string]any) error {
@@ -203,18 +214,15 @@ func (p *plan) run(ctx context.Context, workers uint, dataMap map[string]any) er
 
 	errs := make([]error, 0)
 	for i := range p.order {
-		if ctx.Err() != nil {
-			return errors.Join(append(errs, ctx.Err())...)
+		if err := ctx.Err(); err != nil {
+			return joinErrors(append(errs, err))
 		}
 		err := doWorkAndGetResult(ctx, p.order[i], dataMap, wChan)
 		if err != nil {
 			errs = append(errs, err)
 		}
 	}
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-	return nil
+	return joinErrors(errs)
 }
 
 // Result.Get returns the value of the struct from the result

--- a/plan.go
+++ b/plan.go
@@ -204,7 +204,7 @@ func (p *plan) run(ctx context.Context, workers uint, dataMap map[string]any) er
 	errs := make([]error, 0)
 	for i := range p.order {
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return errors.Join(append(errs, ctx.Err())...)
 		}
 		err := doWorkAndGetResult(ctx, p.order[i], dataMap, wChan)
 		if err != nil {

--- a/plan.go
+++ b/plan.go
@@ -122,7 +122,7 @@ func processWork(ctx context.Context, w work) {
 			w.out <- o
 		}
 	}()
-	fn := reflect.ValueOf(w.builder.Builder)
+	fn := w.builder.fnValue
 	// allow builders to access already built data
 	ctx = AddResultToCtx(ctx, w.dataMap)
 	args := make([]reflect.Value, 1)
@@ -184,9 +184,7 @@ func doWorkAndGetResult(ctx context.Context, builders []*builder, dataMap map[st
 		dataMap[name] = outputs[0].Interface()
 	}
 	if len(errs) > 0 {
-		// we only return the first error
-		// only the first error is returned; aggregate if needed
-		return errs[0]
+		return errors.Join(errs...)
 	}
 	return nil
 }
@@ -205,15 +203,16 @@ func (p *plan) run(ctx context.Context, workers uint, dataMap map[string]any) er
 
 	errs := make([]error, 0)
 	for i := range p.order {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		err := doWorkAndGetResult(ctx, p.order[i], dataMap, wChan)
 		if err != nil {
 			errs = append(errs, err)
 		}
 	}
 	if len(errs) > 0 {
-		// we only return the first error
-		// only the first error is returned; aggregate if needed
-		return errs[0]
+		return errors.Join(errs...)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- **Reflection caching**: Cache `reflect.ValueOf(builder)` in the `builder` struct at registration time, avoiding repeated reflection on every `Run()`/`RunParallel()`
- **Context cancellation**: Check `ctx.Err()` before each execution stage so cancelled plans short-circuit instead of running all remaining stages
- **Error aggregation**: Use `errors.Join(errs...)` instead of returning only the first error, preserving all failure information from parallel builders

## Test plan
- [x] Existing tests pass (`make test -race`), including extensive dependency, plan, and builder tests
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Aggregate and return all collected errors (instead of only the first).
  * Early-abort operations when context cancellation is detected.
  * Reject nil / typed-nil builder inputs and avoid wrapping single errors so original error identities are preserved.

* **Tests**
  * Added unit tests covering nil-builder rejection, context cancellation handling, and error-joining behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->