### PR TITLE
fix: add comma-ok guards for type assertion panics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ import "github.com/go-coldbrew/data-builder"
 
 ## Index
 
+- [Constants](<#constants>)
 - [Variables](<#variables>)
 - [func AddResultToCtx\(ctx context.Context, r Result\) context.Context](<#AddResultToCtx>)
 - [func BuildGraph\(executionPlan Plan, format, file string\) error](<#BuildGraph>)
@@ -28,6 +29,14 @@ import "github.com/go-coldbrew/data-builder"
   - [func GetResultFromCtx\(ctx context.Context\) Result](<#GetResultFromCtx>)
   - [func \(r Result\) Get\(obj any\) any](<#Result.Get>)
 
+
+## Constants
+
+<a name="SupportPackageIsVersion1"></a>SupportPackageIsVersion1 is a compile\-time assertion constant. Downstream packages reference this to enforce version compatibility.
+
+```go
+const SupportPackageIsVersion1 = true
+```
 
 ## Variables
 
@@ -80,7 +89,7 @@ AddResultToCtx adds the given result object to context
 this function should ideally only be used in your tests and/or for debugging modification made to Result obj will NOT persist
 
 <a name="BuildGraph"></a>
-## func [BuildGraph](<https://github.com/go-coldbrew/data-builder/blob/main/plan.go#L305>)
+## func [BuildGraph](<https://github.com/go-coldbrew/data-builder/blob/main/plan.go#L317>)
 
 ```go
 func BuildGraph(executionPlan Plan, format, file string) error
@@ -100,7 +109,7 @@ GetFromResult allows builders to access data built by other builders
 this function enables optional access to data, your code should not rely on values being present, if you have explicit dependency please add them to your function parameters
 
 <a name="IsValidBuilder"></a>
-## func [IsValidBuilder](<https://github.com/go-coldbrew/data-builder/blob/main/databuilder.go#L90>)
+## func [IsValidBuilder](<https://github.com/go-coldbrew/data-builder/blob/main/databuilder.go#L94>)
 
 ```go
 func IsValidBuilder(builder any) error
@@ -109,7 +118,7 @@ func IsValidBuilder(builder any) error
 IsValidBuilder checks if the given function is valid or not
 
 <a name="MaxPlanParallelism"></a>
-## func [MaxPlanParallelism](<https://github.com/go-coldbrew/data-builder/blob/main/plan.go#L317>)
+## func [MaxPlanParallelism](<https://github.com/go-coldbrew/data-builder/blob/main/plan.go#L329>)
 
 ```go
 func MaxPlanParallelism(pl Plan) (uint, error)
@@ -284,7 +293,7 @@ welcome to singapore
 </details>
 
 <a name="New"></a>
-### func [New](<https://github.com/go-coldbrew/data-builder/blob/main/databuilder.go#L174>)
+### func [New](<https://github.com/go-coldbrew/data-builder/blob/main/databuilder.go#L178>)
 
 ```go
 func New() DataBuilder
@@ -378,7 +387,7 @@ GetResultFromCtx gives access to result object at this point in execution
 this function should ideally only be used in your tests and/or for debugging modification made to Result obj may or may not persist
 
 <a name="Result.Get"></a>
-### func \(Result\) [Get](<https://github.com/go-coldbrew/data-builder/blob/main/plan.go#L233>)
+### func \(Result\) [Get](<https://github.com/go-coldbrew/data-builder/blob/main/plan.go#L245>)
 
 ```go
 func (r Result) Get(obj any) any

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ AddResultToCtx adds the given result object to context
 this function should ideally only be used in your tests and/or for debugging modification made to Result obj will NOT persist
 
 <a name="BuildGraph"></a>
-## func [BuildGraph](<https://github.com/go-coldbrew/data-builder/blob/main/plan.go#L317>)
+## func [BuildGraph](<https://github.com/go-coldbrew/data-builder/blob/main/plan.go#L319>)
 
 ```go
 func BuildGraph(executionPlan Plan, format, file string) error
@@ -118,7 +118,7 @@ func IsValidBuilder(builder any) error
 IsValidBuilder checks if the given function is valid or not
 
 <a name="MaxPlanParallelism"></a>
-## func [MaxPlanParallelism](<https://github.com/go-coldbrew/data-builder/blob/main/plan.go#L329>)
+## func [MaxPlanParallelism](<https://github.com/go-coldbrew/data-builder/blob/main/plan.go#L331>)
 
 ```go
 func MaxPlanParallelism(pl Plan) (uint, error)
@@ -387,7 +387,7 @@ GetResultFromCtx gives access to result object at this point in execution
 this function should ideally only be used in your tests and/or for debugging modification made to Result obj may or may not persist
 
 <a name="Result.Get"></a>
-### func \(Result\) [Get](<https://github.com/go-coldbrew/data-builder/blob/main/plan.go#L245>)
+### func \(Result\) [Get](<https://github.com/go-coldbrew/data-builder/blob/main/plan.go#L247>)
 
 ```go
 func (r Result) Get(obj any) any

--- a/plan.go
+++ b/plan.go
@@ -3,6 +3,7 @@ package databuilder
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strconv"
 	"sync"
@@ -141,7 +142,11 @@ func processWork(ctx context.Context, w work) {
 	}
 	o.outputs = fn.Call(args)
 	if len(o.outputs) > 1 && !o.outputs[1].IsNil() {
-		span.SetError(o.outputs[1].Interface().(error)) // nolint: errcheck
+		if errVal, ok := o.outputs[1].Interface().(error); ok {
+			span.SetError(errVal) //nolint:errcheck
+		} else {
+			span.SetError(fmt.Errorf("builder %s: second return value is not an error: %v", w.builder.Name, o.outputs[1].Interface())) //nolint:errcheck
+		}
 	}
 	w.out <- o
 }
@@ -179,7 +184,11 @@ func doWorkAndGetResult(ctx context.Context, builders []*builder, dataMap map[st
 		// 0-> data, 1-> error
 		if !outputs[1].IsNil() {
 			// error occured, add it to the list of errors and continue processing
-			errs = append(errs, outputs[1].Interface().(error))
+			if errVal, ok := outputs[1].Interface().(error); ok {
+			errs = append(errs, errVal)
+		} else {
+			errs = append(errs, fmt.Errorf("builder %s: second return value is not an error: %v", o.builder.Name, outputs[1].Interface()))
+		}
 			continue
 		}
 		// add result

--- a/plan.go
+++ b/plan.go
@@ -177,14 +177,14 @@ func doWorkAndGetResult(ctx context.Context, builders []*builder, dataMap map[st
 	errs := make([]error, 0)
 	for o := range outChan {
 		if o.err != nil {
-			// error occured, return it back and stop processing
+			// error occurred, return it back and stop processing
 			return o.err
 		}
 		outputs := o.outputs
 		// we should only ever have two outputs
 		// 0-> data, 1-> error
 		if !outputs[1].IsNil() {
-			// error occured, add it to the list of errors and continue processing
+			// error occurred, add it to the list of errors and continue processing
 			secondReturn := outputs[1].Interface()
 			if errVal, ok := secondReturn.(error); ok {
 				errs = append(errs, errVal)

--- a/plan.go
+++ b/plan.go
@@ -142,10 +142,11 @@ func processWork(ctx context.Context, w work) {
 	}
 	o.outputs = fn.Call(args)
 	if len(o.outputs) > 1 && !o.outputs[1].IsNil() {
-		if errVal, ok := o.outputs[1].Interface().(error); ok {
+		secondReturn := o.outputs[1].Interface()
+		if errVal, ok := secondReturn.(error); ok {
 			span.SetError(errVal) //nolint:errcheck
 		} else {
-			span.SetError(fmt.Errorf("builder %s: second return value is not an error: %v", w.builder.Name, o.outputs[1].Interface())) //nolint:errcheck
+			span.SetError(fmt.Errorf("builder %s: second return value is not an error (type %T)", w.builder.Name, secondReturn)) //nolint:errcheck
 		}
 	}
 	w.out <- o
@@ -184,11 +185,12 @@ func doWorkAndGetResult(ctx context.Context, builders []*builder, dataMap map[st
 		// 0-> data, 1-> error
 		if !outputs[1].IsNil() {
 			// error occured, add it to the list of errors and continue processing
-			if errVal, ok := outputs[1].Interface().(error); ok {
-			errs = append(errs, errVal)
-		} else {
-			errs = append(errs, fmt.Errorf("builder %s: second return value is not an error: %v", o.builder.Name, outputs[1].Interface()))
-		}
+			secondReturn := outputs[1].Interface()
+			if errVal, ok := secondReturn.(error); ok {
+				errs = append(errs, errVal)
+			} else {
+				errs = append(errs, fmt.Errorf("builder %s: second return value is not an error (type %T)", o.builder.Name, secondReturn))
+			}
 			continue
 		}
 		// add result

--- a/plan_test.go
+++ b/plan_test.go
@@ -94,6 +94,22 @@ func TestPlanRunPartialSuccess(t *testing.T) {
 	goleak.VerifyNone(t)
 }
 
+func TestPlanRun_ErrorFlowWithCommaOk(t *testing.T) {
+	// Verify that the comma-ok type assertion guards in processWork and
+	// doWorkAndGetResult correctly propagate errors from builders.
+	d := testNew(t)
+	err := d.AddBuilders(DBTestFuncErr)
+	assert.NoError(t, err)
+	executionPlan, err := d.Compile(TestStruct1{})
+	assert.NotNil(t, executionPlan)
+	assert.NoError(t, err)
+
+	_, err = executionPlan.Run(context.Background(), TestStruct1{Value: "test"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "encountered an error")
+	goleak.VerifyNone(t)
+}
+
 func ExamplePlan() {
 	b := New()
 	err := b.AddBuilders(DBTestFunc, DBTestFunc4)

--- a/plan_test.go
+++ b/plan_test.go
@@ -105,8 +105,7 @@ func TestPlanRun_ErrorFlowWithCommaOk(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = executionPlan.Run(context.Background(), TestStruct1{Value: "test"})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "encountered an error")
+	assert.ErrorContains(t, err, "encountered an error")
 	goleak.VerifyNone(t)
 }
 


### PR DESCRIPTION
## Summary
- Add comma-ok guards to two unsafe type assertions in `plan.go` that could panic if `reflect.Value.Interface().(error)` fails
- Defense-in-depth: `IsValidBuilder` validates at registration time, but reflection at runtime can still misbehave
- Add `TestPlanRun_ErrorFlowWithCommaOk` to verify error propagation through the guarded path

## Test plan
- [x] `make test` passes with `-race`
- [x] `make lint` clean
- [x] `make doc` regenerated README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new package-version constant and updated function reference links to correct source locations.

* **Bug Fixes**
  * Improved runtime error handling to avoid crashes when components return unexpected types and to provide clearer error messages.

* **Tests**
  * Added a unit test covering the error flow and verifying no goroutine leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->